### PR TITLE
fix: CodigoPostal to address mapping in PrestadorService

### DIFF
--- a/Application/Services/PrestadorService.cs
+++ b/Application/Services/PrestadorService.cs
@@ -331,7 +331,8 @@ public class PrestadorService : IPrestadorService
                 Altura = d.Altura,
                 Piso = d.Piso,
                 Departamento = d.Departamento,
-                ProvinciaCiudad = d.ProvinciaCiudad
+                ProvinciaCiudad = d.ProvinciaCiudad,
+                CodigoPostal = d.CodigoPostal
             }).ToList() ?? new()
         };
     }


### PR DESCRIPTION
The CodigoPostal field is now included when mapping address data in PrestadorService. This ensures postal code information is available in the returned address objects.